### PR TITLE
Add getAllPoolsVolume endpoint for single-endpoint querying

### DIFF
--- a/pages/api/getAllPoolsVolume/ethereum.js
+++ b/pages/api/getAllPoolsVolume/ethereum.js
@@ -1,0 +1,40 @@
+import getFactoryAPYs from 'pages/api/getFactoryAPYs';
+import { arrayToHashmap, sum } from 'utils/Array';
+import Request from 'utils/Request';
+import { fn } from 'utils/api';
+
+export default fn(async () => {
+  const [
+    mainPoolsStats,
+    mainCryptoPoolsStats,
+    factoryV1Apys,
+    factoryV2Apys,
+  ] = await Promise.all([
+    (await Request.get('https://stats.curve.fi/raw-stats/apys.json')).json(),
+    (await Request.get('https://stats.curve.fi/raw-stats-crypto/apys.json')).json(),
+    getFactoryAPYs.straightCall({ version: 1 }),
+    getFactoryAPYs.straightCall({ version: 2 }),
+  ]);
+
+  const poolsVolume = {
+    ...mainPoolsStats.volume,
+    ...mainCryptoPoolsStats.volume,
+    ...arrayToHashmap(factoryV1Apys.poolDetails.map(({ poolSymbol, poolAddress, volume }) => [
+      `${poolSymbol}-${poolAddress}`,
+      volume,
+    ])),
+    ...arrayToHashmap(factoryV2Apys.poolDetails.map(({ poolSymbol, poolAddress, volume }) => [
+      `${poolSymbol}-${poolAddress}`,
+      volume,
+    ])),
+  };
+
+  const totalVolume = sum(Array.from(Object.values(poolsVolume)));
+
+  return {
+    poolsVolume,
+    totalVolume,
+  };
+}, {
+  maxAge: 10 * 60, // 10m
+});

--- a/pages/api/getFactoryAPYs.js
+++ b/pages/api/getFactoryAPYs.js
@@ -13,7 +13,7 @@ const web3 = new Web3(`https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEM
 const BASE_API_DOMAIN = IS_DEV ? 'http://localhost:3000' : 'https://api.curve.fi';
 
 export default fn(async (query) => {
-    const version = query.version === '2' ? 2 : 1;
+    const version = Number(query.version) === 2 ? 2 : 1;
 
     let registryAddress = await getFactoryRegistry()
     let multicallAddress = await getMultiCall()


### PR DESCRIPTION
Merges together volumes from raw-stats, raw-stats-crypto, and facto v1+v2, and serves only that to give an easy window into curve's total daily volume on ethereum