### PR TITLE
Add special prop for gauges not voted in yet

### DIFF
--- a/pages/api/getGauges.js
+++ b/pages/api/getGauges.js
@@ -765,6 +765,7 @@ export default fn(async () => {
         gauge: '0x82d0aDea8C4CF2fc84A499b568F4C1194d63113d',
         type: 'crypto',
         factory: true,
+        hasNoCrv: true, // Hasn't been voted in yet, isn't in gauge controller, doesn't receive CRV
       },
     }
 


### PR DESCRIPTION
Since calling gauge_types on the controller for a gauge that's not voted 
in yet reverts, this prop helps not calling it on these gauges