### PR TITLE
Remove fallback token usdPrice based on asset type

### DIFF
--- a/pages/api/getFactoryV2Pools/index.js
+++ b/pages/api/getFactoryV2Pools/index.js
@@ -386,7 +386,7 @@ export default fn(async ({ blockchainId }) => {
     );
 
     const assetTypeIndex = Array.from(assetTypeMap.values()).indexOf(assetTypeName);
-    const assetTypePrice = assetTypePricesMap[assetTypeIndex];
+    // const assetTypePrice = assetTypePricesMap[assetTypeIndex];
 
     const coins = poolInfo.coinsAddresses
       .filter((address) => address !== '0x0000000000000000000000000000000000000000')
@@ -395,7 +395,8 @@ export default fn(async ({ blockchainId }) => {
 
         return {
           ...mergedCoinData[key],
-          usdPrice: mergedCoinData[key]?.usdPrice || assetTypePrice || 0,
+          // usdPrice: mergedCoinData[key]?.usdPrice || assetTypePrice || 0,
+          usdPrice: mergedCoinData[key]?.usdPrice || 0,
         };
       });
 


### PR DESCRIPTION
This fallback based on asset type (e.g. if a stable pool is of type 
"usd", then we assumed that each token in it, even if it was brand new 
and unknown, was worth about $1) falls apart when users create pools 
with millions of valueless tokens: we must not assume those tokens to be 
worth anything