### PR TITLE
Remove custom avax f 30 gauge

### DIFF
--- a/pages/api/getFactoryV2Pools/index.js
+++ b/pages/api/getFactoryV2Pools/index.js
@@ -8,7 +8,6 @@ import { flattenArray, sum, arrayToHashmap } from 'utils/Array';
 import getTokensPrices from 'utils/data/tokens-prices';
 import getAssetsPrices from 'utils/data/assets-prices';
 import getFactoryV2GaugeRewards from 'utils/data/getFactoryV2GaugeRewards';
-import getFactoryV2SidechainGaugeRewards from 'utils/data/getFactoryV2SidechainGaugeRewards';
 import getMainRegistryPools from 'pages/api/getMainRegistryPools';
 import getGauges from 'pages/api/getGauges';
 import { IS_DEV } from 'constants/AppConstants';
@@ -49,39 +48,7 @@ const getEthereumOnlyData = async () => {
     gaugeRewards,
     factoryGaugesPoolAddressesAndAssetPricesMap,
   };
-};
-
-const getSidechainOnlyData = async (blockchainId) => {
-  const [
-    { gauges: gaugesData },
-    gaugeRewards,
-  ] = await Promise.all([
-    getGauges.straightCall(),
-    getFactoryV2SidechainGaugeRewards(blockchainId),
-  ]);
-
-  const gaugesDataArray = Array.from(Object.values(gaugesData));
-  const factoryGaugesPoolAddressesAndCoingeckoIdMap = arrayToHashmap(
-    gaugesDataArray
-      .filter(({ factory }) => factory === true)
-      .map(({ swap, type: coingeckoId }) => [swap, coingeckoId])
-    );
-
-  const gaugesAssetPrices = await getAssetsPrices(Array.from(Object.values(factoryGaugesPoolAddressesAndCoingeckoIdMap)));
-  const factoryGaugesPoolAddressesAndAssetPricesMap = arrayToHashmap(
-    Array.from(Object.entries(factoryGaugesPoolAddressesAndCoingeckoIdMap))
-      .map(([address, coingeckoId], i) => [
-        address.toLowerCase(),
-        gaugesAssetPrices[coingeckoId]
-      ])
-  );
-
-  return {
-    gaugesDataArray,
-    gaugeRewards,
-    factoryGaugesPoolAddressesAndAssetPricesMap,
-  };
-};
+}
 
 export default fn(async ({ blockchainId }) => {
   if (typeof blockchainId === 'undefined') blockchainId = 'ethereum'; // Default value
@@ -149,10 +116,6 @@ export default fn(async ({ blockchainId }) => {
 
   const ethereumOnlyData = blockchainId === 'ethereum' ?
     await getEthereumOnlyData() :
-    undefined;
-
-  const sidechainOnlyData = blockchainId !== 'ethereum' ?
-    await getSidechainOnlyData(blockchainId) :
     undefined;
 
   const assetTypePricesMapPromise = new Promise(async (resolve) => {
@@ -407,15 +370,7 @@ export default fn(async ({ blockchainId }) => {
     const gaugeAddress = typeof ethereumOnlyData !== 'undefined' ?
       ethereumOnlyData.gaugesDataArray.find(({ swap }) => swap.toLowerCase() === poolInfo.address.toLowerCase())?.gauge?.toLowerCase() :
       undefined;
-    const sidechainGaugeAddress = typeof sidechainOnlyData !== 'undefined' ?
-      sidechainOnlyData.gaugesDataArray.find(({ sideSwap }) => sideSwap?.toLowerCase() === poolInfo.address.toLowerCase())?.sideGauge?.toLowerCase() :
-      undefined;
-
-    const gaugeRewardsInfo = (
-      gaugeAddress ? ethereumOnlyData.gaugeRewards[gaugeAddress] :
-      sidechainGaugeAddress ? sidechainOnlyData.gaugeRewards[sidechainGaugeAddress] :
-      undefined
-    );
+    const gaugeRewardsInfo = gaugeAddress ? ethereumOnlyData.gaugeRewards[gaugeAddress] : undefined;
 
     return {
       ...poolInfo,
@@ -423,15 +378,8 @@ export default fn(async ({ blockchainId }) => {
       assetTypeName,
       coins,
       usdTotal,
-      gaugeAddress: gaugeAddress || sidechainGaugeAddress,
+      gaugeAddress,
       gaugeRewards: gaugeRewardsInfo,
-      sidechainOnlyGaugeInfo: (
-        typeof sidechainOnlyData?.gaugesData !== 'undefined' ? {
-          sideSwap: sidechainOnlyData.gaugesData[`${blockchainId}-${poolInfo.id}`]?.sideSwap,
-          sideGauge: sidechainOnlyData.gaugesData[`${blockchainId}-${poolInfo.id}`]?.sideGauge,
-          sideStreamer: sidechainOnlyData.gaugesData[`${blockchainId}-${poolInfo.id}`]?.sideStreamer,
-        } : undefined
-      ),
     };
   });
 

--- a/pages/api/getGauges.js
+++ b/pages/api/getGauges.js
@@ -531,17 +531,6 @@ export default fn(async () => {
         type: 'crypto',
         side_chain: true
       },
-      "avalanche-factory-v2-30": {
-        swap: '0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c',
-        swap_token: '0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c',
-        name: 'avalanche-factory-v2-30',
-        sideSwap: '0x3a43A5851A3e3E0e25A3c1089670269786be1577', // Swap on the sidechain
-        sideGauge: '0xA4106e1206d313a86051c6B5bc475181a81Dbc0f', // Gauge on the sidechain
-        sideStreamer: '0xa465A135399Fc49bC0B51acD023Cde0aF160A53f', // Streamer on the sidechain
-        type: 'stable',
-        side_chain: true,
-        factory: true,
-      },
       "harmony-3pool": {
         swap: '0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c',
         swap_token: '0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c',


### PR DESCRIPTION
Reverts #63, now that a gauge facto exists for avax, there's now a facto gauge for this pool; and there'll be gauge factos for every sidechain soon enough, so no need for custom deployments like this in the future

Goes w/ https://github.com/curvefi/curve-ui-private/pull/391