### PR TITLE
Refactor facto gauge extra rewards code to fix gauge usd total for apy calc

### DIFF
--- a/pages/api/getPools/index.js
+++ b/pages/api/getPools/index.js
@@ -607,7 +607,33 @@ export default fn(async ({ blockchainId, registryId }) => {
       coins: augmentedCoins,
       usdTotal,
       gaugeAddress,
-      gaugeRewards: gaugeRewardsInfo,
+      gaugeRewards: (
+        typeof gaugeRewardsInfo === 'undefined' ?
+          undefined :
+          gaugeRewardsInfo.map(({
+            apyData,
+            ...rewardInfo
+          }) => {
+            const gaugeTotalSupply = apyData.totalSupply;
+            const poolTotalSupply = poolInfo.totalSupply / 1e18;
+            const gaugeUsdTotal = gaugeTotalSupply / poolTotalSupply * usdTotal;
+
+            return {
+              ...rewardInfo,
+              check: {
+                gaugeTotalSupply,
+                poolTotalSupply,
+                gaugeUsdTotal,
+                ratioStaked: (gaugeTotalSupply / poolTotalSupply),
+              },
+              apy: (
+                apyData.isRewardStillActive ?
+                  apyData.rate * 86400 * 365 * apyData.tokenPrice / gaugeUsdTotal * 100 :
+                  0
+              ),
+            };
+          })
+      ),
     };
   });
 

--- a/pages/api/getPools/index.js
+++ b/pages/api/getPools/index.js
@@ -620,12 +620,6 @@ export default fn(async ({ blockchainId, registryId }) => {
 
             return {
               ...rewardInfo,
-              check: {
-                gaugeTotalSupply,
-                poolTotalSupply,
-                gaugeUsdTotal,
-                ratioStaked: (gaugeTotalSupply / poolTotalSupply),
-              },
               apy: (
                 apyData.isRewardStillActive ?
                   apyData.rate * 86400 * 365 * apyData.tokenPrice / gaugeUsdTotal * 100 :

--- a/utils/data/getFactoryV2GaugeRewards.js
+++ b/utils/data/getFactoryV2GaugeRewards.js
@@ -102,11 +102,12 @@ export default memoize(async (factoryGaugesAddresses) => {
       name: tokenName,
       symbol: tokenSymbol,
       decimals: tokenDecimals,
-      apy: (
-        isRewardStillActive ?
-          rate * 86400 * 365 * tokenPrice / totalSupply * 100 :
-          0
-      ),
+      apyData: {
+        isRewardStillActive,
+        tokenPrice,
+        rate,
+        totalSupply,
+      },
     };
   });
 


### PR DESCRIPTION
Used to take into account totalSupply for facto pools (stable and 
crypto), assuming $1 lp token value for all those, leading to incorrect 
extra rewards apy in pools where lp token had a different value