### PR TITLE
Enable to run codeq analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,8 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, * ]
+    branches-ignore:
+      - main
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]


### PR DESCRIPTION
This PR fixes the issue of not triggering codeq analysis in GitHub actions. The successfully executed run can be seen at https://github.com/martinkersner/curve-api/actions/runs/2273361741.