### PR TITLE
Remove internal calls

### DIFF
--- a/constants/AppConstants.js
+++ b/constants/AppConstants.js
@@ -1,6 +1,7 @@
 const IS_DEV = process.env.NODE_ENV === 'development';
 
-const BASE_API_DOMAIN = IS_DEV ? 'http://localhost:3000' : 'https://api.curve.fi';
+// const BASE_API_DOMAIN = IS_DEV ? 'http://localhost:3000' : 'https://api.curve.fi';
+const BASE_API_DOMAIN = IS_DEV ? 'http://localhost:3000' : 'https://curve-api-git-remove-internal-calls-curvefi.vercel.app/';
 
 const REWARD_TOKENS_REPLACE_MAP = {
 };

--- a/constants/AppConstants.js
+++ b/constants/AppConstants.js
@@ -1,7 +1,6 @@
 const IS_DEV = process.env.NODE_ENV === 'development';
 
-// const BASE_API_DOMAIN = IS_DEV ? 'http://localhost:3000' : 'https://api.curve.fi';
-const BASE_API_DOMAIN = IS_DEV ? 'http://localhost:3000' : 'https://curve-api-git-remove-internal-calls-curvefi.vercel.app/';
+const BASE_API_DOMAIN = IS_DEV ? 'http://localhost:3000' : 'https://api.curve.fi';
 
 const REWARD_TOKENS_REPLACE_MAP = {
 };

--- a/constants/Web3.js
+++ b/constants/Web3.js
@@ -5,7 +5,7 @@ const DECIMALS_WEI = 1e18;
 const DECIMALS_GWEI = 1e9;
 const MAX_UINT256 = BN(2).pow(256).minus(1);
 
-const RPC_URL = `https://eth-mainnet.alchemyapi.io/v2/qxMTl7zqGwCJqITZC5kxUn12Fxs9yRTM`;
+const RPC_URL = `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY_ETHEREUM_NEW}`;
 const RPC_BACKUP_URL = `https://eth.chain.satoshiandkin.com/u/${process.env.LLAMANODES_API_KEY}`;
 
 const RPC_URL_BSC = 'https://bsc-dataseed.binance.org/';

--- a/constants/Web3.js
+++ b/constants/Web3.js
@@ -5,7 +5,7 @@ const DECIMALS_WEI = 1e18;
 const DECIMALS_GWEI = 1e9;
 const MAX_UINT256 = BN(2).pow(256).minus(1);
 
-const RPC_URL = `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY_ETHEREUM}`;
+const RPC_URL = `https://eth-mainnet.alchemyapi.io/v2/qxMTl7zqGwCJqITZC5kxUn12Fxs9yRTM`;
 const RPC_BACKUP_URL = `https://eth.chain.satoshiandkin.com/u/${process.env.LLAMANODES_API_KEY}`;
 
 const RPC_URL_BSC = 'https://bsc-dataseed.binance.org/';

--- a/constants/configs.js
+++ b/constants/configs.js
@@ -185,7 +185,7 @@ const configs = {
     chainId: 43114,
     nativeCurrencyCoingeckoId: 'avalanche-2',
     platformCoingeckoId: 'avalanche',
-    rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+    rpcUrl: `https://api.avax.network/ext/bc/C/rpc?token=${process.env.API_KEY_AVALANCHE}`,
     nativeAssetId: 'avax', // Coin id from the blockchain's coins config
     nativeAssetErc20WrapperId: 'wavax',
     multicallAddress: '0xa00FB557AA68d2e98A830642DBbFA534E8512E5f',

--- a/pages/api/getAllGauges.js
+++ b/pages/api/getAllGauges.js
@@ -11,14 +11,14 @@
 import Web3 from 'web3';
 import partition from 'lodash.partition';
 import configs from 'constants/configs';
-import getFactoGauges from 'pages/api/getFactoGauges';
 import { fn } from 'utils/api';
 import { multiCall } from 'utils/Calls';
+import { API } from 'utils/Request';
 import getAllCurvePoolsData from 'utils/data/curve-pools-data';
 import { arrayOfIncrements, flattenArray, arrayToHashmap } from 'utils/Array';
 import { sequentialPromiseMap } from 'utils/Async';
-import GAUGE_CONTROLLER_ABI from '../../constants/abis/gauge_controller.json';
-import GAUGE_ABI from '../../constants/abis/example_gauge_2.json';
+import GAUGE_CONTROLLER_ABI from 'constants/abis/gauge_controller.json';
+import GAUGE_ABI from 'constants/abis/example_gauge_2.json';
 
 /* eslint-disable object-curly-spacing, object-curly-newline, quote-props, quotes, key-spacing, comma-spacing */
 const GAUGE_IS_ROOT_GAUGE_ABI = [{"stateMutability":"view","type":"function","name":"bridger","inputs":[],"outputs":[{"name":"","type":"address"}]}];
@@ -243,7 +243,7 @@ export default fn(async () => {
 
   const factoGauges = await sequentialPromiseMap(blockchainIds, (blockchainIdsChunk) => (
     Promise.all(blockchainIdsChunk.map((blockchainId) => (
-      getFactoGauges.straightCall({ blockchainId }).then(({ gauges }) => (
+      API.get(`getFactoGauges/${blockchainId}`).then(({ gauges }) => (
         gauges.map((gaugeData) => ({
           ...gaugeData,
           blockchainId,

--- a/pages/api/getAllPoolsVolume/index.js
+++ b/pages/api/getAllPoolsVolume/index.js
@@ -1,9 +1,10 @@
 import { fn } from 'utils/api';
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
 export default fn(async ({ blockchainId }) => {
 
   if (typeof blockchainId === 'undefined') blockchainId = 'ethereum'; // Default value
-  const { data: { totalVolume, cryptoShare } } = await (await fetch(`https://api.curve.fi/api/getSubgraphData/${blockchainId}`)).json();
+  const { data: { totalVolume, cryptoShare } } = await (await fetch(`${BASE_API_DOMAIN}/api/getSubgraphData/${blockchainId}`)).json();
 
   return {
     totalVolume,

--- a/pages/api/getApys.js
+++ b/pages/api/getApys.js
@@ -4,10 +4,10 @@
 
 import getAPY from 'utils/data/getAPY';
 import getCRVAPY from 'utils/data/getCRVAPY';
-import getMainPoolsGaugeRewards from 'pages/api/getMainPoolsGaugeRewards';
+import { API } from 'utils/Request';
 import { arrayToHashmap } from 'utils/Array';
 import pools from 'constants/pools';
-import { fn } from '../../utils/api';
+import { fn } from 'utils/api';
 
 export default fn(async ({ address }) => {
   const [
@@ -15,7 +15,7 @@ export default fn(async ({ address }) => {
     { weeklyApy: baseApys },
     { CRVAPYs: crvApys, boosts, CRVprice: crvPrice },
   ] = await Promise.all([
-    getMainPoolsGaugeRewards.straightCall(),
+    API.get('getMainPoolsGaugeRewards'),
     getAPY(),
     getCRVAPY(address || '0x0000000000000000000000000000000000000000'),
   ]);

--- a/pages/api/getCoins.js
+++ b/pages/api/getCoins.js
@@ -1,5 +1,6 @@
 import Web3 from 'web3';
 import WEB3_CONSTANTS from 'constants/Web3';
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 import { fn } from 'utils/api';
 import registryAbi from 'constants/abis/registry-v1.1.json';
 import multicallAbi from 'constants/abis/multicall.json';
@@ -7,7 +8,6 @@ import { getMultiCall, getRegistry } from 'utils/getters';
 import erc20Abi from 'constants/abis/erc20.json';
 
 const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
-const BASE_API_DOMAIN = 'https://api.curve.fi';
 
 export default fn(async () => {
   const registryMainAddress = await getRegistry();

--- a/pages/api/getCoins.js
+++ b/pages/api/getCoins.js
@@ -1,10 +1,10 @@
 import Web3 from 'web3';
 import WEB3_CONSTANTS from 'constants/Web3';
-import { fn } from '../../utils/api';
-import registryAbi from '../../constants/abis/registry-v1.1.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import { getMultiCall, getRegistry } from '../../utils/getters';
-import erc20Abi from '../../constants/abis/erc20.json';
+import { fn } from 'utils/api';
+import registryAbi from 'constants/abis/registry-v1.1.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import { getMultiCall, getRegistry } from 'utils/getters';
+import erc20Abi from 'constants/abis/erc20.json';
 
 const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 const BASE_API_DOMAIN = 'https://api.curve.fi';

--- a/pages/api/getETHprice.js
+++ b/pages/api/getETHprice.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import Web3 from 'web3';
 import WEB3_CONSTANTS from 'constants/Web3';
-import { fn } from '../../utils/api';
-import aggregatorInterfaceABI from '../../constants/abis/aggregator.json';
+import { fn } from 'utils/api';
+import aggregatorInterfaceABI from 'constants/abis/aggregator.json';
 
 const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 const chainlinkETHUSDaddress = '0xF79D6aFBb6dA890132F9D7c355e3015f15F3406F';

--- a/pages/api/getFactoGauges/[blockchainId].js
+++ b/pages/api/getFactoGauges/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import getFactoGaugesApiFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getFactoGaugesApiFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getFactoGauges/index.js
+++ b/pages/api/getFactoGauges/index.js
@@ -10,7 +10,7 @@ import gaugeControllerAbi from 'constants/abis/gauge_controller.json';
 import factorypool3Abi from 'constants/abis/factory_swap.json';
 import { multiCall } from 'utils/Calls';
 import { arrayToHashmap, arrayOfIncrements, flattenArray } from 'utils/Array';
-import getPools from 'pages/api/getPools';
+import { API } from 'utils/Request';
 import configs from 'constants/configs';
 import getFactoryV2SidechainGaugeRewards from 'utils/data/getFactoryV2SidechainGaugeRewards';
 
@@ -206,18 +206,18 @@ export default fn(async ({ blockchainId }) => {
     factoPools,
     factoCryptoPools,
   ] = await Promise.all([(
-    (await getPools.straightCall({ blockchainId, registryId: 'main', preventQueryingFactoData: true })).poolData
+    (await API.get(`getPools/${blockchainId}/main/true`)).poolData
   ), (
     hasCryptoPools ?
-      (await getPools.straightCall({ blockchainId, registryId: 'crypto', preventQueryingFactoData: true })).poolData :
+      (await API.get(`getPools/${blockchainId}/crypto/true`)).poolData :
       []
   ), (
     hasFactoPools ?
-      (await getPools.straightCall({ blockchainId, registryId: 'factory', preventQueryingFactoData: true })).poolData :
+      (await API.get(`getPools/${blockchainId}/factory/true`)).poolData :
       []
   ), (
     hasFactoCryptoPools ?
-      (await getPools.straightCall({ blockchainId, registryId: 'factory-crypto', preventQueryingFactoData: true })).poolData :
+      (await API.get(`getPools/${blockchainId}/factory-crypto/true`)).poolData :
       []
   )]);
 

--- a/pages/api/getFactoGaugesCrvRewards/[blockchainId].js
+++ b/pages/api/getFactoGaugesCrvRewards/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import getFactoGaugesCrvRewardsApiFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getFactoGaugesCrvRewardsApiFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getFactoGaugesCrvRewards/index.js
+++ b/pages/api/getFactoGaugesCrvRewards/index.js
@@ -4,9 +4,7 @@
 
 import { fn } from 'utils/api';
 import getAssetsPrices from 'utils/data/assets-prices';
-
-import getFactoGauges from 'pages/api/getFactoGauges';
-import getPools from 'pages/api/getPools';
+import { API } from 'utils/Request';
 import configs from 'constants/configs';
 
 export default fn(async ({ blockchainId }) => {
@@ -14,13 +12,13 @@ export default fn(async ({ blockchainId }) => {
 
   const config = configs[blockchainId];
 
-  const { gauges } = await getFactoGauges.straightCall({ blockchainId });
-  const { poolData: mainPoolData } = await getPools.straightCall({ blockchainId, registryId: 'main' });
-  const { poolData: cryptoPoolData } = await getPools.straightCall({ blockchainId, registryId: 'crypto' });
-  const { poolData: factoStablePoolData } = await getPools.straightCall({ blockchainId, registryId: 'factory' });
+  const { gauges } = await API.get(`getFactoGauges/${blockchainId}`);
+  const { poolData: mainPoolData } = await API.get(`getPools/${blockchainId}/main`);
+  const { poolData: cryptoPoolData } = await API.get(`getPools/${blockchainId}/crypto`);
+  const { poolData: factoStablePoolData } = await API.get(`getPools/${blockchainId}/factory`);
   const { poolData: factoCryptoPoolData } = (
     config.getFactoryCryptoRegistryAddress ?
-      await getPools.straightCall({ blockchainId, registryId: 'factory-crypto' }) :
+      await API.get(`getPools/${blockchainId}/factory-crypto`) :
       { poolData: [] }
   );
   const poolData = [...mainPoolData, ...cryptoPoolData, ...factoStablePoolData, ...factoCryptoPoolData];

--- a/pages/api/getFactoryAPYs-kava.js
+++ b/pages/api/getFactoryAPYs-kava.js
@@ -10,7 +10,7 @@ import Web3 from 'web3';
 import BigNumber from 'big-number';
 import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
-import getPoolsFn from 'pages/api/getPools';
+import { API } from 'utils/Request';
 import configs from 'constants/configs';
 import { fn } from 'utils/api';
 import registryAbi from 'constants/abis/factory_registry.json';
@@ -27,7 +27,7 @@ export default fn(async (query) => {
   let multicallAddress = config.multicallAddress;
 	let registry = new web3.eth.Contract(registryAbi, registryAddress);
 	let multicall = new web3.eth.Contract(multicallAbi, multicallAddress)
-  let res = await getPoolsFn.straightCall({ blockchainId: 'kava', registryId: 'factory' })
+  let res = await API.get('getPools/kava/factory');
   let poolDetails = [];
   let totalVolume = 0
 

--- a/pages/api/getFactoryAPYs-moonbeam.js
+++ b/pages/api/getFactoryAPYs-moonbeam.js
@@ -10,12 +10,12 @@ import Web3 from 'web3';
 import BigNumber from 'big-number';
 import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
-import configs from '../../constants/configs';
-import { fn } from '../../utils/api';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import factorypool3Abi from '../../constants/abis/factory_swap.json';
+import configs from 'constants/configs';
+import { fn } from 'utils/api';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import factorypool3Abi from 'constants/abis/factory_swap.json';
 
 const web3 = new Web3(configs.moonbeam.rpcUrl);
 

--- a/pages/api/getFactoryAPYs-optimism.js
+++ b/pages/api/getFactoryAPYs-optimism.js
@@ -2,12 +2,12 @@ import Web3 from 'web3';
 import BigNumber from 'big-number';
 import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
-import configs from '../../constants/configs';
-import { fn } from '../../utils/api';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import factorypool3Abi from '../../constants/abis/factory_swap.json';
+import configs from 'constants/configs';
+import { fn } from 'utils/api';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import factorypool3Abi from 'constants/abis/factory_swap.json';
 
 const web3 = new Web3(`https://opt-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY_OPTIMISM}`);
 

--- a/pages/api/getFactoryAPYs-xdai.js
+++ b/pages/api/getFactoryAPYs-xdai.js
@@ -2,12 +2,12 @@ import Web3 from 'web3';
 import BigNumber from 'big-number';
 import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
-import configs from '../../constants/configs';
-import { fn } from '../../utils/api';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import factorypool3Abi from '../../constants/abis/factory_swap.json';
+import configs from 'constants/configs';
+import { fn } from 'utils/api';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import factorypool3Abi from 'constants/abis/factory_swap.json';
 
 const web3 = new Web3(configs.xdai.rpcUrl);
 

--- a/pages/api/getFactoryAPYs/_sidechains.js
+++ b/pages/api/getFactoryAPYs/_sidechains.js
@@ -9,7 +9,7 @@ export default async ({ blockchainId, version }) => {
 
     const poolDetails = [];
 
-    const { data: { poolList: poolsStats } } = await (await fetch(`https://api.curve.fi/api/getSubgraphData/${blockchainId}`)).json();
+    const { data: { poolList: poolsStats } } = await (await fetch(`${BASE_API_DOMAIN}/api/getSubgraphData/${blockchainId}`)).json();
     poolData.forEach((pool, index) => {
       const lcSwapAddress = pool.address.toLowerCase();
       const poolStats = poolsStats.find(({ address }) => address.toLowerCase() === lcSwapAddress);

--- a/pages/api/getFactoryAPYs/ethereum.js
+++ b/pages/api/getFactoryAPYs/ethereum.js
@@ -34,7 +34,7 @@ export default fn(async ({ version }) => {
       version === 'crypto' ? 'getPools/ethereum/factory-crypto' :
       undefined
     );
-    const { data: { poolData } } = await (await fetch(`https://api.curve.fi/api/${factoryPoolsApiEndpoint}`)).json()
+    const { data: { poolData } } = await (await fetch(`${BASE_API_DOMAIN}/api/${factoryPoolsApiEndpoint}`)).json()
 
     let poolDetails = [];
     let totalVolume = 0

--- a/pages/api/getFactoryCryptoPools/[blockchainId].js
+++ b/pages/api/getFactoryCryptoPools/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import getFactoryCryptoPoolsApiFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getFactoryCryptoPoolsApiFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getFactoryCryptoPools/index.js
+++ b/pages/api/getFactoryCryptoPools/index.js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import { API } from 'utils/Request';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   API.get(`getPools/${blockchainId}/factory-crypto`)
 ), {
   maxAge: 60,

--- a/pages/api/getFactoryPools.js
+++ b/pages/api/getFactoryPools.js
@@ -2,11 +2,11 @@ import Web3 from 'web3';
 import WEB3_CONSTANTS from 'constants/Web3';
 import configs from 'constants/configs';
 
-import { fn } from '../../utils/api';
-import { getMultiCall, getFactoryRegistry } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
+import { fn } from 'utils/api';
+import { getMultiCall, getFactoryRegistry } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
 
 const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 

--- a/pages/api/getFactoryTVL.js
+++ b/pages/api/getFactoryTVL.js
@@ -3,11 +3,11 @@ import Web3 from 'web3';
 import BigNumber from 'big-number';
 import WEB3_CONSTANTS from 'constants/Web3';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
 
 const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 

--- a/pages/api/getFactoryTVL.js
+++ b/pages/api/getFactoryTVL.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 import WEB3_CONSTANTS from 'constants/Web3';
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
 import { fn } from 'utils/api';
 import { getFactoryRegistry, getMultiCall } from 'utils/getters';
@@ -14,7 +15,7 @@ const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 
 export default fn(async () => {
 
-    let res = await (await fetch(`https://api.curve.fi/api/getFactoryV2Pools`)).json()
+    let res = await (await fetch(`${BASE_API_DOMAIN}/api/getFactoryV2Pools`)).json()
     const factoryBalances = res.data.tvl
     return { factoryBalances };
 

--- a/pages/api/getFactoryV2Pools/[blockchainId].js
+++ b/pages/api/getFactoryV2Pools/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import getFactoryV2PoolsApiFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getFactoryV2PoolsApiFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getFactoryV2Pools/index.js
+++ b/pages/api/getFactoryV2Pools/index.js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import { API } from 'utils/Request';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   API.get(`getPools/${blockchainId}/factory`)
 ), {
   maxAge: 60,

--- a/pages/api/getFactoryV2Pools/index.js
+++ b/pages/api/getFactoryV2Pools/index.js
@@ -1,8 +1,8 @@
 import { fn } from 'utils/api';
-import getPoolsFn from 'pages/api/getPools';
+import { API } from 'utils/Request';
 
 export default fn(async ({ blockchainId }) => (
-  getPoolsFn.straightCall({ blockchainId, registryId: 'factory' })
+  API.get(`getPools/${blockchainId}/factory`)
 ), {
   maxAge: 60,
 });

--- a/pages/api/getGas.js
+++ b/pages/api/getGas.js
@@ -1,5 +1,5 @@
 import memoize from 'memoizee';
-import { fn } from '../../utils/api';
+import { fn } from 'utils/api';
 
 const blocknativeApiFetchOptions = {
   method: 'GET',

--- a/pages/api/getGauges/[blockchainId].js
+++ b/pages/api/getGauges/[blockchainId].js
@@ -1,8 +1,8 @@
 import { fn } from 'utils/api';
-import { API } from 'utils/Request';
+import getGaugesFn from './index';
 
 export default fn(async ({ blockchainId }) => (
-  API.get(`getPools/${blockchainId}/factory-crypto`)
+  getGaugesFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,
 });

--- a/pages/api/getGauges/[blockchainId].js
+++ b/pages/api/getGauges/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import getGaugesFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getGaugesFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getGauges/index.js
+++ b/pages/api/getGauges/index.js
@@ -5,17 +5,17 @@
 
 import Web3 from 'web3';
 import WEB3_CONSTANTS from 'constants/Web3';
-import getFactoGauges from 'pages/api/getFactoGauges';
+import { API } from 'utils/Request';
 import { fn } from 'utils/api';
 import { arrayToHashmap, flattenArray } from 'utils/Array';
 import { sequentialPromiseMap } from 'utils/Async';
-import aggregatorInterfaceABI from '../../constants/abis/aggregator.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import gaugeControllerAbi from '../../constants/abis/gauge_controller.json';
-import exampleGaugeAbi from '../../constants/abis/example_gauge.json';
-import swapAbi from '../../constants/abis/tripool_swap.json';
+import aggregatorInterfaceABI from 'constants/abis/aggregator.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import gaugeControllerAbi from 'constants/abis/gauge_controller.json';
+import exampleGaugeAbi from 'constants/abis/example_gauge.json';
+import swapAbi from 'constants/abis/tripool_swap.json';
 
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
 
 const CHAINS_WITH_FACTORY_GAUGES = [
   'fantom',
@@ -26,7 +26,7 @@ const CHAINS_WITH_FACTORY_GAUGES = [
   'xdai',
 ];
 
-const web3 = new Web3(WEB3_CONSTANTS.RPC_BACKUP_URL);
+const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 
 export default fn(async ({ blockchainId } = {}) => {
   if (typeof blockchainId === 'undefined') blockchainId = undefined; // Default value (return gauges for all chains)
@@ -1238,7 +1238,7 @@ export default fn(async ({ blockchainId } = {}) => {
   if (chainsToQuery.length > 1) console.trace();
   const factoGauges = await sequentialPromiseMap(chainsToQuery, (blockchainIds) => (
     Promise.all(blockchainIds.map((blockchainId) => (
-      getFactoGauges.straightCall({ blockchainId })
+      API.get(`getFactoGauges/${blockchainId}`)
     )))
   ), 4);
 

--- a/pages/api/getHiddenPools.js
+++ b/pages/api/getHiddenPools.js
@@ -1,4 +1,4 @@
-import { fn } from '../../utils/api';
+import { fn } from 'utils/api';
 
 const HIDDEN_POOLS_IDS = {
   ethereum: [

--- a/pages/api/getMainPoolsGaugeRewards.js
+++ b/pages/api/getMainPoolsGaugeRewards.js
@@ -11,7 +11,7 @@ import { ZERO_ADDRESS } from 'utils/Web3/web3';
 import getTokensPrices from 'utils/data/tokens-prices';
 import getAssetsPrices from 'utils/data/assets-prices';
 import getFactoryV2GaugeRewards from 'utils/data/getFactoryV2GaugeRewards';
-import getGauges from 'pages/api/getGauges';
+import { API } from 'utils/Request';
 import ERC20_ABI from 'constants/abis/erc20.json';
 import getAavePoolRewardsInfo from 'utils/data/getAavePoolRewardsInfo';
 import RewardContractV1ABI from 'utils/data/abis/json/reward-contracts/v1.json';
@@ -64,7 +64,7 @@ const FACTORY_GAUGES_ADDED_TO_MAIN_LIST_ADDRESSES_REF_ASSET_PRICE = {
 const GAUGES_PARTIAL_ABI = [{"name":"reward_contract","outputs":[{"type":"address","name":""}],"inputs":[],"stateMutability":"view","type":"function","gas":2051},{"name":"totalSupply","outputs":[{"type":"uint256","name":""}],"inputs":[],"stateMutability":"view","type":"function","gas":1691},{"stateMutability":"view","type":"function","name":"reward_tokens","inputs":[{"name":"arg0","type":"uint256"}],"outputs":[{"name":"","type":"address"}],"gas":3787},{"name":"rewarded_token","outputs":[{"type":"address","name":""}],"inputs":[],"stateMutability":"view","type":"function","gas":2201}];
 
 export default fn(async () => {
-  let { gauges } = await getGauges.straightCall();
+  let { gauges } = await API.get('getGauges');
 
   //empty gauges cause reverts
   const remove = [

--- a/pages/api/getMainRegistryPools/[blockchainId].js
+++ b/pages/api/getMainRegistryPools/[blockchainId].js
@@ -1,8 +1,8 @@
 import { fn } from 'utils/api';
-import { API } from 'utils/Request';
+import getMainRegistryPoolsFn from './index';
 
 export default fn(async ({ blockchainId }) => (
-  API.get(`getPools/${blockchainId}/factory-crypto`)
+  getMainRegistryPoolsFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,
 });

--- a/pages/api/getMainRegistryPools/[blockchainId].js
+++ b/pages/api/getMainRegistryPools/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import getMainRegistryPoolsFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getMainRegistryPoolsFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getMainRegistryPools/index.js
+++ b/pages/api/getMainRegistryPools/index.js
@@ -1,10 +1,10 @@
 import Web3 from 'web3';
 import configs from 'constants/configs';
 import { ZERO_ADDRESS } from 'utils/Web3';
-import { fn } from '../../utils/api';
-import { getRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
+import { fn } from 'utils/api';
+import { getRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
 
 export default fn(async ({ blockchainId } = {}) => {
   if (typeof blockchainId === 'undefined') blockchainId = 'ethereum';

--- a/pages/api/getMainRegistryPoolsAndLpTokens/[blockchainId].js
+++ b/pages/api/getMainRegistryPoolsAndLpTokens/[blockchainId].js
@@ -1,0 +1,8 @@
+import { fn } from 'utils/api';
+import getMainRegistryPoolsAndLpTokensFn from './index';
+
+export default fn(async ({ blockchainId }) => (
+  getMainRegistryPoolsAndLpTokensFn.straightCall({ blockchainId })
+), {
+  maxAge: 60,
+});

--- a/pages/api/getMainRegistryPoolsAndLpTokens/[blockchainId].js
+++ b/pages/api/getMainRegistryPoolsAndLpTokens/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import getMainRegistryPoolsAndLpTokensFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getMainRegistryPoolsAndLpTokensFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getMainRegistryPoolsAndLpTokens/index.js
+++ b/pages/api/getMainRegistryPoolsAndLpTokens/index.js
@@ -1,6 +1,6 @@
 import Web3 from 'web3';
 import configs from 'constants/configs';
-import getMainRegistryPoolsFn from 'pages/api/getMainRegistryPools';
+import { API } from 'utils/Request';
 import { multiCall } from 'utils/Calls';
 import { fn } from 'utils/api';
 import { ZERO_ADDRESS } from 'utils/Web3';
@@ -9,7 +9,7 @@ import POOL_SWAP_ABI from 'utils/data/abis/json/aave/swap.json';
 export default fn(async ({ blockchainId } = {}) => {
   if (typeof blockchainId === 'undefined') blockchainId = 'ethereum';
 
-  const { poolList: mainRegistryPools } = await getMainRegistryPoolsFn.straightCall({ blockchainId });
+  const { poolList: mainRegistryPools } = await API.get(`getMainRegistryPools/${blockchainId}`);
 
   const config = configs[blockchainId];
   const web3Side = new Web3(config.rpcUrl);

--- a/pages/api/getPoolList/[blockchainId].js
+++ b/pages/api/getPoolList/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import getPoolListApiFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getPoolListApiFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getPools/[...params].js
+++ b/pages/api/getPools/[...params].js
@@ -1,8 +1,8 @@
 import { fn } from 'utils/api';
 import getPoolsApiFn from './index';
 
-export default fn(async ({ params: [blockchainId, registryId] }) => (
-  getPoolsApiFn.straightCall({ blockchainId, registryId })
+export default fn(async ({ params: [blockchainId, registryId, preventQueryingFactoData] }) => (
+  getPoolsApiFn.straightCall({ blockchainId, registryId, preventQueryingFactoData })
 ), {
   maxAge: 60,
 });

--- a/pages/api/getRegistryAddress.js
+++ b/pages/api/getRegistryAddress.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Web3 from 'web3';
-import { fn } from '../../utils/api';
-import { getRegistry } from '../../utils/getters';
+import { fn } from 'utils/api';
+import { getRegistry } from 'utils/getters';
 
 export default fn(async () => {
 

--- a/pages/api/getSubgraphData/[blockchainId].js
+++ b/pages/api/getSubgraphData/[blockchainId].js
@@ -1,7 +1,7 @@
 import { fn } from 'utils/api';
 import  getSubgraphDataApiFn from './index';
 
-export default fn(async ({ blockchainId }) => (
+export default fn(async ({ blockchainId = 'ethereum' }) => (
   getSubgraphDataApiFn.straightCall({ blockchainId })
 ), {
   maxAge: 60,

--- a/pages/api/getTVL.js
+++ b/pages/api/getTVL.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 import WEB3_CONSTANTS from 'constants/Web3';
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
 import { fn } from 'utils/api';
 import { getRegistry, getMultiCall } from 'utils/getters';
@@ -19,10 +20,10 @@ export default fn(async () => {
     let tvl = 0;
 
 
-    let resCrypto = await (await fetch(`https://api.curve.fi/api/getPools/ethereum/crypto`)).json()
-    let resMain = await (await fetch(`https://api.curve.fi/api/getPools/ethereum/main`)).json()
-    let resFacto = await (await fetch(`https://api.curve.fi/api/getPools/ethereum/factory`)).json()
-    let resCryptoFacto = await (await fetch(`https://api.curve.fi/api/getPools/ethereum/factory-crypto`)).json()
+    let resCrypto = await (await fetch(`${BASE_API_DOMAIN}/api/getPools/ethereum/crypto`)).json()
+    let resMain = await (await fetch(`${BASE_API_DOMAIN}/api/getPools/ethereum/main`)).json()
+    let resFacto = await (await fetch(`${BASE_API_DOMAIN}/api/getPools/ethereum/factory`)).json()
+    let resCryptoFacto = await (await fetch(`${BASE_API_DOMAIN}/api/getPools/ethereum/factory-crypto`)).json()
 
     tvl = +resCrypto.data.tvl + +resMain.data.tvl + +resFacto.data.tvl + +resCryptoFacto.data.tvl
 
@@ -42,7 +43,7 @@ export default fn(async () => {
     let sideChainTVL = 0
     await Promise.all(
       endPoints.map(async (endPoint) => {
-        let res = await (await fetch(`https://api.curve.fi/api/${endPoint}`)).json()
+        let res = await (await fetch(`${BASE_API_DOMAIN}/api/${endPoint}`)).json()
         let sideChain  = {
           'chain': endPoint.replace('getTVL', ''),
           'tvl': parseFloat(res.data.tvl)

--- a/pages/api/getTVL.js
+++ b/pages/api/getTVL.js
@@ -3,11 +3,11 @@ import Web3 from 'web3';
 import BigNumber from 'big-number';
 import WEB3_CONSTANTS from 'constants/Web3';
 
-import { fn } from '../../utils/api';
-import { getRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
+import { fn } from 'utils/api';
+import { getRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
 
 const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 

--- a/pages/api/getTVLArbitrum.js
+++ b/pages/api/getTVLArbitrum.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import aavePool from '../../constants/abis/pools/aave.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import aavePool from 'constants/abis/pools/aave.json';
 
 const web3 = new Web3(`https://arb-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY_ARBITRUM}`);
 

--- a/pages/api/getTVLArbitrum.js
+++ b/pages/api/getTVLArbitrum.js
@@ -8,6 +8,7 @@ import registryAbi from 'constants/abis/factory_registry.json';
 import multicallAbi from 'constants/abis/multicall.json';
 import erc20Abi from 'constants/abis/erc20.json';
 import aavePool from 'constants/abis/pools/aave.json';
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
 const web3 = new Web3(`https://arb-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY_ARBITRUM}`);
 
@@ -84,7 +85,7 @@ export default fn(async () => {
       }
 
 
-    let res = await (await fetch(`https://api.curve.fi/api/getFactoryV2Pools/arbitrum`)).json()
+    let res = await (await fetch(`${BASE_API_DOMAIN}/api/getFactoryV2Pools/arbitrum`)).json()
     tvl += res.data.tvlAll
     const factory = {
       'tvl': res.data.tvlAll

--- a/pages/api/getTVLAurora.js
+++ b/pages/api/getTVLAurora.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import aavePool from '../../constants/abis/pools/aave.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import aavePool from 'constants/abis/pools/aave.json';
 
 const web3 = new Web3(`https://mainnet.aurora.dev`);
 

--- a/pages/api/getTVLAvalanche.js
+++ b/pages/api/getTVLAvalanche.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
 import { fn } from 'utils/api';
 import { getFactoryRegistry, getMultiCall } from 'utils/getters';
@@ -71,7 +72,7 @@ export default fn(async () => {
         }
       }
 
-    let res = await (await fetch(`https://api.curve.fi/api/getFactoryV2Pools/avalanche`)).json()
+    let res = await (await fetch(`${BASE_API_DOMAIN}/api/getFactoryV2Pools/avalanche`)).json()
     tvl += res.data.tvlAll
     const factory = {
       'tvl': res.data.tvlAll

--- a/pages/api/getTVLAvalanche.js
+++ b/pages/api/getTVLAvalanche.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import aavePool from '../../constants/abis/pools/aave.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import aavePool from 'constants/abis/pools/aave.json';
 
 const web3 = new Web3(`https://api.avax.network/ext/bc/C/rpc`);
 

--- a/pages/api/getTVLCrypto.js
+++ b/pages/api/getTVLCrypto.js
@@ -3,12 +3,12 @@ import Web3 from 'web3';
 import BigNumber from 'big-number';
 import WEB3_CONSTANTS from 'constants/Web3';
 
-import { fn } from '../../utils/api';
-import { getRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import cryptoPoolAbi from '../../constants/abis/crypto_pool.json';
+import { fn } from 'utils/api';
+import { getRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import cryptoPoolAbi from 'constants/abis/crypto_pool.json';
 
 const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 

--- a/pages/api/getTVLFantom.js
+++ b/pages/api/getTVLFantom.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import poolTwo from '../../constants/abis/pools/2pool.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import poolTwo from 'constants/abis/pools/2pool.json';
 
 const web3 = new Web3(`https://rpc.ftm.tools/`);
 

--- a/pages/api/getTVLFantom.js
+++ b/pages/api/getTVLFantom.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
-
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 import { fn } from 'utils/api';
 import { getFactoryRegistry, getMultiCall } from 'utils/getters';
 import registryAbi from 'constants/abis/factory_registry.json';
@@ -87,10 +87,10 @@ export default fn(async () => {
         }
         let virtual_price = await poolC.methods.get_virtual_price().call();
         pools[key].virtual_price = virtual_price
-        
+
       }
 
-      let res = await (await fetch(`https://api.curve.fi/api/getFactoryV2Pools/fantom`)).json()
+      let res = await (await fetch(`${BASE_API_DOMAIN}/api/getFactoryV2Pools/fantom`)).json()
       tvl += res.data.tvlAll
       const factory = {
         'tvl': res.data.tvlAll

--- a/pages/api/getTVLHarmony.js
+++ b/pages/api/getTVLHarmony.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import aavePool from '../../constants/abis/pools/aave.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import aavePool from 'constants/abis/pools/aave.json';
 
 const web3 = new Web3(`https://api.harmony.one`);
 

--- a/pages/api/getTVLKava.js
+++ b/pages/api/getTVLKava.js
@@ -1,7 +1,7 @@
 import Web3 from 'web3';
 import configs from 'constants/configs';
 
-import getPoolsFn from 'pages/api/getPools';
+import { API } from 'utils/Request';
 import { fn } from 'utils/api';
 import erc20Abi from 'constants/abis/erc20.json';
 import aavePool from 'constants/abis/pools/aave.json';
@@ -45,7 +45,7 @@ export default fn(async () => {
         }
       }
 
-    const factoDetails = await getPoolsFn.straightCall({ blockchainId: 'kava', registryId: 'factory' })
+    const factoDetails = await API.get('getPools/kava/factory')
     tvl += factoDetails.tvlAll
     const factory = {
       tvl: factoDetails.tvlAll

--- a/pages/api/getTVLMoonbeam.js
+++ b/pages/api/getTVLMoonbeam.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import aavePool from '../../constants/abis/pools/aave.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import aavePool from 'constants/abis/pools/aave.json';
 
 const web3 = new Web3(`https://moonbeam.api.onfinality.io/public`);
 

--- a/pages/api/getTVLMoonbeam.js
+++ b/pages/api/getTVLMoonbeam.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
-
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 import { fn } from 'utils/api';
 import { getFactoryRegistry, getMultiCall } from 'utils/getters';
 import registryAbi from 'constants/abis/factory_registry.json';
@@ -55,7 +55,7 @@ export default fn(async () => {
         }
       }
 
-    const factoDetails = await (await fetch(`https://api.curve.fi/api/getFactoryV2Pools/moonbeam`)).json()
+    const factoDetails = await (await fetch(`${BASE_API_DOMAIN}/api/getFactoryV2Pools/moonbeam`)).json()
     tvl += factoDetails.data.tvlAll
     const factory = {
       tvl: factoDetails.data.tvlAll

--- a/pages/api/getTVLOptimism.js
+++ b/pages/api/getTVLOptimism.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import aavePool from '../../constants/abis/pools/aave.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import aavePool from 'constants/abis/pools/aave.json';
 
 const web3 = new Web3(`https://mainnet.optimism.io`);
 

--- a/pages/api/getTVLOptimism.js
+++ b/pages/api/getTVLOptimism.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
-
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 import { fn } from 'utils/api';
 import { getFactoryRegistry, getMultiCall } from 'utils/getters';
 import registryAbi from 'constants/abis/factory_registry.json';
@@ -55,7 +55,7 @@ export default fn(async () => {
         }
       }
 
-      const factoDetails = await (await fetch(`https://api.curve.fi/api/getFactoryV2Pools/optimism`)).json()
+      const factoDetails = await (await fetch(`${BASE_API_DOMAIN}/api/getFactoryV2Pools/optimism`)).json()
       tvl += factoDetails.data.tvlAll
       const factory = {
         'tvl': factoDetails.data.tvlAll

--- a/pages/api/getTVLPolygon.js
+++ b/pages/api/getTVLPolygon.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import aavePool from '../../constants/abis/pools/aave.json';
+import { fn } from 'utils/api';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import aavePool from 'constants/abis/pools/aave.json';
 
 const web3 = new Web3(`https://polygon-rpc.com/`);
 

--- a/pages/api/getTVLPolygon.js
+++ b/pages/api/getTVLPolygon.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
-
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 import { fn } from 'utils/api';
 import { getFactoryRegistry, getMultiCall } from 'utils/getters';
 import registryAbi from 'constants/abis/factory_registry.json';
@@ -94,7 +94,7 @@ export default fn(async () => {
         }
       }
 
-    let res = await (await fetch(`https://api.curve.fi/api/getFactoryV2Pools/polygon`)).json()
+    let res = await (await fetch(`${BASE_API_DOMAIN}/api/getFactoryV2Pools/polygon`)).json()
     tvl += res.data.tvlAll
     const factory = {
       'tvl': res.data.tvlAll

--- a/pages/api/getTVLxDai.js
+++ b/pages/api/getTVLxDai.js
@@ -2,13 +2,13 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 
-import { fn } from '../../utils/api';
-import configs from '../../constants/configs';
-import { getFactoryRegistry, getMultiCall } from '../../utils/getters';
-import registryAbi from '../../constants/abis/factory_registry.json';
-import multicallAbi from '../../constants/abis/multicall.json';
-import erc20Abi from '../../constants/abis/erc20.json';
-import aavePool from '../../constants/abis/pools/aave.json';
+import { fn } from 'utils/api';
+import configs from 'constants/configs';
+import { getFactoryRegistry, getMultiCall } from 'utils/getters';
+import registryAbi from 'constants/abis/factory_registry.json';
+import multicallAbi from 'constants/abis/multicall.json';
+import erc20Abi from 'constants/abis/erc20.json';
+import aavePool from 'constants/abis/pools/aave.json';
 
 const web3 = new Web3(configs.xdai.rpcUrl);
 

--- a/pages/api/getWeeklyFees.js
+++ b/pages/api/getWeeklyFees.js
@@ -2,11 +2,11 @@ import axios from 'axios';
 import Web3 from 'web3';
 import BigNumber from 'big-number';
 import WEB3_CONSTANTS from 'constants/Web3';
-import { fn } from '../../utils/api';
-import { getFeeDistributor } from '../../utils/getters';
-import { getThursdayUTCTimestamp } from '../../utils/helpers';
-import distributorAbi from '../../constants/abis/distributor.json';
-import tripoolSwapAbi from '../../constants/abis/tripool_swap.json';
+import { fn } from 'utils/api';
+import { getFeeDistributor } from 'utils/getters';
+import { getThursdayUTCTimestamp } from 'utils/helpers';
+import distributorAbi from 'constants/abis/distributor.json';
+import tripoolSwapAbi from 'constants/abis/tripool_swap.json';
 
 const web3 = new Web3(WEB3_CONSTANTS.RPC_URL);
 

--- a/utils/Request.js
+++ b/utils/Request.js
@@ -10,6 +10,7 @@
  */
 
 import formUrlEncoded from 'form-urlencoded';
+import { BASE_API_DOMAIN } from 'constants/AppConstants';
 
 class Request {
   static send(url, data = {}, customSettings = {}) {
@@ -67,4 +68,11 @@ class Request {
   }
 }
 
+const API = {
+  get: async (path, data) => (
+    (await (await Request.get(`${BASE_API_DOMAIN}/api/${path}`, data)).json()).data
+  ),
+};
+
 export default Request;
+export { API };

--- a/utils/api.js
+++ b/utils/api.js
@@ -36,7 +36,8 @@ const fn = (cb, options = {}) => {
     name = null, // Name, used for logging purposes
   } = options;
 
-  const callback = (false && maxAgeSec !== null) ?
+  // In prod, each endpoint is a lambda, hence no shared memory, hence no point in memoizing
+  const callback = (IS_DEV && maxAgeSec !== null) ?
     memoize(async (query) => logRuntime(() => addGeneratedTime(cb(query)), name, query), {
       promise: true,
       maxAge: maxAgeSec * 1000,
@@ -51,8 +52,12 @@ const fn = (cb, options = {}) => {
         res.status(200).json(formatJsonSuccess(data));
       })
       .catch((err) => {
-        if (IS_DEV) throw err;
-        else res.status(500).json(formatJsonError(err));
+        if (IS_DEV) {
+          console.log(err);
+          throw err;
+        } else {
+          res.status(500).json(formatJsonError(err));
+        }
       })
   );
 

--- a/utils/api.js
+++ b/utils/api.js
@@ -36,7 +36,7 @@ const fn = (cb, options = {}) => {
     name = null, // Name, used for logging purposes
   } = options;
 
-  const callback = maxAgeSec !== null ?
+  const callback = (false && maxAgeSec !== null) ?
     memoize(async (query) => logRuntime(() => addGeneratedTime(cb(query)), name, query), {
       promise: true,
       maxAge: maxAgeSec * 1000,
@@ -47,7 +47,7 @@ const fn = (cb, options = {}) => {
   const apiCall = async (req, res) => (
     Promise.resolve(callback(req.query))
       .then((data) => {
-        if (maxAgeSec !== null) res.setHeader('Cache-Control', `max-age=0, s-maxage=${maxAgeSec}, stale-while-revalidate`);
+        if (maxAgeSec !== null) res.setHeader('Cache-Control', `s-maxage=${maxAgeSec}, stale-while-revalidate=${maxAgeSec}`);
         res.status(200).json(formatJsonSuccess(data));
       })
       .catch((err) => {

--- a/utils/data/curve-pools-data.js
+++ b/utils/data/curve-pools-data.js
@@ -1,7 +1,7 @@
 import memoize from 'memoizee';
 import { flattenArray } from 'utils/Array';
 import { sequentialPromiseFlatMap } from 'utils/Async';
-import getPools from 'pages/api/getPools';
+import { API } from 'utils/Request';
 
 const attachBlockchainId = (blockchainId, poolData) => ({
   ...poolData,
@@ -21,13 +21,13 @@ const attachFactoryTag = (poolData) => ({
 const getAllCurvePoolsData = memoize(async (blockchainIds) => (
   flattenArray(await sequentialPromiseFlatMap(blockchainIds, async (blockchainId) => (
     Promise.all([
-      (getPools.straightCall({ blockchainId, registryId: 'main', preventQueryingFactoData: true }))
+      API.get(`getPools/${blockchainId}/main/true`)
         .then((res) => res.poolData.map((poolData) => attachBlockchainId(blockchainId, poolData)).map((poolData) => attachRegistryId('main', poolData))),
-      (getPools.straightCall({ blockchainId, registryId: 'crypto', preventQueryingFactoData: true }))
+      API.get(`getPools/${blockchainId}/crypto/true`)
         .then((res) => res.poolData.map((poolData) => attachBlockchainId(blockchainId, poolData)).map((poolData) => attachRegistryId('crypto', poolData))),
-      (getPools.straightCall({ blockchainId, registryId: 'factory', preventQueryingFactoData: true }))
+      API.get(`getPools/${blockchainId}/factory/true`)
         .then((res) => res.poolData.map((poolData) => attachBlockchainId(blockchainId, poolData)).map((poolData) => attachRegistryId('factory', poolData)).map(attachFactoryTag)),
-      (getPools.straightCall({ blockchainId, registryId: 'factory-crypto', preventQueryingFactoData: true }))
+      API.get(`getPools/${blockchainId}/factory-crypto/true`)
         .then((res) => res.poolData.map((poolData) => attachBlockchainId(blockchainId, poolData)).map((poolData) => attachRegistryId('factory-crypto', poolData)).map(attachFactoryTag)),
     ])
   )))

--- a/utils/data/getFactoryV2GaugeRewards.js
+++ b/utils/data/getFactoryV2GaugeRewards.js
@@ -6,7 +6,7 @@ import { multiCall } from 'utils/Calls';
 import { flattenArray, uniq } from 'utils/Array';
 import { getNowTimestamp } from 'utils/Date';
 import getTokensPrices from 'utils/data/tokens-prices';
-import getGauges from 'pages/api/getGauges';
+import { API } from 'utils/Request';
 import ERC20_ABI from 'constants/abis/erc20.json';
 
 // eslint-disable-next-line
@@ -15,7 +15,7 @@ const FACTORY_GAUGES_ABI = [{"stateMutability":"view","type":"function","name":"
 export default memoize(async ({ factoryGaugesAddresses, blockchainId } = {}) => {
   if (typeof blockchainId === 'undefined') blockchainId = undefined; // Default value
   if (typeof factoryGaugesAddresses === 'undefined') {
-    const { gauges } = await getGauges.straightCall({ blockchainId });
+    const { gauges } = await API.get(`getGauges/${blockchainId}`);
 
     const factoryGauges = Array.from(Object.values(gauges)).filter(({ factory, side_chain }) => factory && !side_chain);
     factoryGaugesAddresses = factoryGauges.map(({ gauge }) => gauge); // eslint-disable-line no-param-reassign


### PR DESCRIPTION
This PR was a tentative to use how vercel apis work (each endpoint is run by a standalone lambda on invocation) to our advantage, by using cached-at-the-edge endpoints to save on work and requests. The in-memory caching that we have inside that codebase is obviously never taken advantage of in a per-function execution environment.

After monitoring web3 requests with a separate alchemy api key for this deployment, this didn't lead to any material difference in usage.