### PR TITLE
Add gaugeCrvApy prop to getPools endpoint 

### DIFF
--- a/constants/PoolAddressInternalIdMap.js
+++ b/constants/PoolAddressInternalIdMap.js
@@ -71,6 +71,7 @@ const map = {
     [lc('0xecd5e75afb02efa118af914515d6521aabd189f1')]: 'tusd',
     [lc('0xfd5db7463a3ab53fd211b4af195c5bccc1a03890')]: 'eurt',
     [lc('0xa1F8A6807c402E4A15ef4EBa36528A3FED24E577')]: 'frxeth',
+    [lc('0xf253f83AcA21aAbD2A20553AE0BF7F65C755A07F')]: 'sbtc2',
   },
   arbitrum: {
     [lc('0x7f90122bf0700f9e7e1f688fe926940e8839f353')]: '2pool',


### PR DESCRIPTION
The `/getPools/ethereum/*` endpoint now returns all CRV and extra rewards apys. Sidechains will soon have the same props available on their own `/getPools/<chain-id>/*` endpoints